### PR TITLE
DF42 (two clicks issue)

### DIFF
--- a/Link_globalPay/cartridges/int_globalpay_sfra/cartridge/templates/default/checkout/billing/globalpaycreditcards.isml
+++ b/Link_globalPay/cartridges/int_globalpay_sfra/cartridge/templates/default/checkout/billing/globalpaycreditcards.isml
@@ -44,6 +44,8 @@ function gatherBrowserData() {
  return clientData;
 }
 
+document.getElementById("threedsdata").value = JSON.stringify(gatherBrowserData());
+
 cardForm.on("token-success", (resp) => {
     // add payment token to form as a hidden input
     const token = document.createElement("input");


### PR DESCRIPTION
On page load threedsdata is blank,it requires two clicks to place order in credit card (bug fix)

Signed-off-by: Nevil Alexander Pereira <m1067575@mindtree.com>